### PR TITLE
Fix start-up compilation settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "name": "Amiga 500",
             "config": "A500",
             "program": "${workspaceFolder}/${config:amiga.program}",
-            "kickstart": "D:\\!emulators\\WinUAE\\rom\\Kickstart1.3.rom",
+            "kickstart": "${config:amiga.rom-paths.A500}",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ i'm not an amiga guru yet, but this one could be useful as an example if you wan
 
 ## building instructions
 
-get Visual Studio Code + [vscode-amiga-debug](https://github.com/BartmanAbyss/vscode-amiga-debug), set it up for Amiga 500 config (make sure to locate a Kickstart 1.3 ROM!), switch to project directory and press F5 to compile and run :)
+get Visual Studio Code + [vscode-amiga-debug](https://github.com/BartmanAbyss/vscode-amiga-debug), set it up for Amiga 500 config (make sure to locate a Kickstart 1.3 ROM! (in VSCode > Preferences > Settings > Amiga C/C++ Compile,Debug > amiga.rom-paths.A500)), switch to project directory and press F5 to compile and run :)
 
 if you want to build an ADF image, head to `out` folder, fixup tool paths in `make_release.bat` and run it.
 

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- `demarination\obj\` folder must be created before compilation (make and gcc can't create directories by default);
- Barman's plugin already has a path for your `kick13.rom`, no need to specify absolute paths in `launch.json`